### PR TITLE
depends_on small fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3"
 
 services:
+
   v4_0_5:
     container_name: CVE_2022_34265_v4.0.5
     build: ./
@@ -8,8 +9,9 @@ services:
       - 4131:8000
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
     command: bash -c "python3 manage.py makemigrations && python3 manage.py migrate && python3 manage.py runserver 0.0.0.0:8000"
+
   postgres:
     image: postgres:latest
     restart: always
@@ -20,4 +22,9 @@ services:
       POSTGRES_DB: vuln
       TZ: "Asia/Tokyo"
       PGPORT: 5433
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 


### PR DESCRIPTION
Hi! 

Here's some little problem in your docker-compose.yml file.

You specified depends_on for container start, not for moment when Postgres in container will be ready to accept connections.

Due to that, i found a small problem when user has powerful PC with SSD or so, container will start fast enough, but Postgres won't be initialized when vulnerable app start. It causes vulnerable app to broke

```
CVE_2022_34265_v4.0.5 | Traceback (most recent call last):
CVE_2022_34265_v4.0.5 |   File "/app/manage.py", line 22, in <module>
CVE_2022_34265_v4.0.5 |     main()
CVE_2022_34265_v4.0.5 |   File "/app/manage.py", line 18, in main
CVE_2022_34265_v4.0.5 |     execute_from_command_line(sys.argv)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
CVE_2022_34265_v4.0.5 |     utility.execute()
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
CVE_2022_34265_v4.0.5 |     self.fetch_command(subcommand).run_from_argv(self.argv)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 414, in run_from_argv
CVE_2022_34265_v4.0.5 |     self.execute(*args, **cmd_options)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 460, in execute
CVE_2022_34265_v4.0.5 |     output = self.handle(*args, **options)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 98, in wrapped
CVE_2022_34265_v4.0.5 |     res = handle_func(*args, **kwargs)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/commands/migrate.py", line 91, in handle
CVE_2022_34265_v4.0.5 |     self.check(databases=[database])
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 487, in check
CVE_2022_34265_v4.0.5 |     all_issues = checks.run_checks(
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/checks/registry.py", line 88, in run_checks
CVE_2022_34265_v4.0.5 |     new_errors = check(app_configs=app_configs, databases=databases)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/core/checks/model_checks.py", line 36, in check_all_models
CVE_2022_34265_v4.0.5 |     errors.extend(model.check(**kwargs))
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/models/base.py", line 1461, in check
CVE_2022_34265_v4.0.5 |     *cls._check_indexes(databases),
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/models/base.py", line 1864, in _check_indexes
CVE_2022_34265_v4.0.5 |     connection.features.supports_covering_indexes
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/functional.py", line 49, in __get__
CVE_2022_34265_v4.0.5 |     res = instance.__dict__[self.name] = self.func(instance)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/postgresql/features.py", line 84, in is_postgresql_11
CVE_2022_34265_v4.0.5 |     return self.connection.pg_version >= 110000
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/functional.py", line 49, in __get__
CVE_2022_34265_v4.0.5 |     res = instance.__dict__[self.name] = self.func(instance)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/postgresql/base.py", line 354, in pg_version
CVE_2022_34265_v4.0.5 |     with self.temporary_connection():
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/contextlib.py", line 135, in __enter__
CVE_2022_34265_v4.0.5 |     return next(self.gen)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 639, in temporary_connection
CVE_2022_34265_v4.0.5 |     with self.cursor() as cursor:
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
CVE_2022_34265_v4.0.5 |     return func(*args, **kwargs)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 284, in cursor
CVE_2022_34265_v4.0.5 |     return self._cursor()
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 260, in _cursor
CVE_2022_34265_v4.0.5 |     self.ensure_connection()
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
CVE_2022_34265_v4.0.5 |     return func(*args, **kwargs)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 243, in ensure_connection
CVE_2022_34265_v4.0.5 |     with self.wrap_database_errors:
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/utils.py", line 91, in __exit__
CVE_2022_34265_v4.0.5 |     raise dj_exc_value.with_traceback(traceback) from exc_value
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 244, in ensure_connection
CVE_2022_34265_v4.0.5 |     self.connect()
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
CVE_2022_34265_v4.0.5 |     return func(*args, **kwargs)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/base/base.py", line 225, in connect
CVE_2022_34265_v4.0.5 |     self.connection = self.get_new_connection(conn_params)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/utils/asyncio.py", line 26, in inner
CVE_2022_34265_v4.0.5 |     return func(*args, **kwargs)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/django/db/backends/postgresql/base.py", line 203, in get_new_connection
CVE_2022_34265_v4.0.5 |     connection = Database.connect(**conn_params)
CVE_2022_34265_v4.0.5 |   File "/usr/local/lib/python3.10/site-packages/psycopg2/__init__.py", line 127, in connect
CVE_2022_34265_v4.0.5 |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
CVE_2022_34265_v4.0.5 | django.db.utils.OperationalError: could not connect to server: Connection refused
CVE_2022_34265_v4.0.5 | 	Is the server running on host "postgres" (192.168.160.2) and accepting
CVE_2022_34265_v4.0.5 | 	TCP/IP connections on port 5433?
```