### PR TITLE
Fixes 'docker-compose build' error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
 


### PR DESCRIPTION
Fixes following error related to docker-compose build:

```
# docker-compose build
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.v4_0_5.depends_on contains an invalid type, it should be an array
```